### PR TITLE
Add config details in .pt files for easier loading

### DIFF
--- a/distill.py
+++ b/distill.py
@@ -198,7 +198,10 @@ def main(data_files, teacher, student, pretrained):
                     patience_counter = 0
                     if step % save_every == 0:
                         checkpoint_file = os.path.join(save_path, f"student_step{step}.pt")
-                        torch.save(student_model.state_dict(), checkpoint_file)
+                        torch.save({
+                            'config': json.dumps(student_config),
+                            'model': student_model.state_dict(),
+                            }, checkpoint_file)
                         print(f"✅ Saved checkpoint: {checkpoint_file}")
                 else:
                     patience_counter += 1


### PR DESCRIPTION
Currently when loading the models elsewhere, one has to find the details about the model config in the source code directly, or in a logged stdout with the run parameters. It would be easier to load models in other contexts, if the model config was just directly included in the .pt files.

Feel free to change the implementation if I missed something